### PR TITLE
Show unassigned shards in all searches

### DIFF
--- a/src/es/commands/shards.py
+++ b/src/es/commands/shards.py
@@ -32,7 +32,7 @@ def show_details(shards):
                                 shard.num_shard,
                                 shard.shard_type,
                                 shard.size,
-                                shard.node,
+                                shard.node or "(no node)",
                                 shard.status,
                                 shard.extra))
 


### PR DESCRIPTION
Unassigned shards don't have a "NODE" in the output of ES, so they were not being considered valid lines by the regex.